### PR TITLE
Replace self-implemented `studly_case` function

### DIFF
--- a/app/UserSearch/UserSearch.php
+++ b/app/UserSearch/UserSearch.php
@@ -31,7 +31,7 @@ class UserSearch
 
     private static function createFilterDecorator($name)
     {
-        return __NAMESPACE__ . '\\Filters\\' . str_replace(' ', '', ucwords(str_replace('_', ' ', $name)));
+        return __NAMESPACE__ . '\\Filters\\' . studly_case($name);
     }
 
     private static function isValidDecorator($decorator)


### PR DESCRIPTION
Laravel has a built-in function function [`studly_case`](https://github.com/laravel/framework/blob/5.2/src/Illuminate/Support/helpers.php#L819) (also available as [`Illuminate\Support\Str::studly`](https://github.com/laravel/framework/blob/5.2/src/Illuminate/Support/Str.php#L428)) which caches the results for faster multiple-access. This should be used instead of re-implementing its functionality.
